### PR TITLE
Fixed: some strings and arrays in the context can break the template rendering due to PHP callables

### DIFF
--- a/dja/template/base.php
+++ b/dja/template/base.php
@@ -1599,7 +1599,7 @@ class Variable {
                     }
                 }
 
-                if (is_callable($current)) {
+                if (is_callable($current) && !is_string($current) && !is_array($current)) {
                     if (py_getattr($current, 'do_not_call_in_templates', False)) {
                     } elseif (py_getattr($current, 'alters_data', False)) {
                         $current = Dja::getSetting('TEMPLATE_STRING_IF_INVALID');


### PR DESCRIPTION
PHP can recognize an array or a string as a callable, causing unwanted changes to the template rendering process.
Example:

```
$template = new Template('Hello, {{ username }}!');
$context = new Context(['username' => 'Max']);
echo $template->render($context);
```

Expected:
`Hello, Max!`

Got:
`Hello, !`

It happens because 'max' is a function name in PHP, and `is_callable('max')` evaluates to `true`.
We have to be more strict here.
